### PR TITLE
content: remove trailing colons from headings

### DIFF
--- a/content/posts/datenmanagement-übung/index.mdx
+++ b/content/posts/datenmanagement-übung/index.mdx
@@ -43,7 +43,7 @@ Das Ziel der Aufgabe ist es, die "UglyDataCollection", also das hässliche Entle
 - Welche **Dateiformate** sollten für die **Speicherung** gewählt werden? Sie müssen die Dateien nicht unbedingt konvertieren, aber notieren Sie sich, welche Dateiformate besser für eine (Langzeit-)Archivierung geeignet wären.
 - **Dokumentieren** Sie Ihre Schritte bitte unbedingt in einer Readme-Datei oder auf einem Blatt Papier, damit Sie diese nachvollziehen und mit der Musterlösung vergleichen können. Außerdem ist, wie Sie bereits gelernt haben, die Dokumentation ein wichtiger Teil eines guten Datenmanagements.
 
-### **Vergleich**
+### Vergleich
 
 **Schritt 3:** Wenn Sie der Meinung sind, die Aufgabe erfolgreich erledigt und die hässliche Datensammlung in einen schönen Schwan verwandelt zu haben, dann laden Sie sich die Musterlösung herunter und vergleichen Sie das Ergebnis! In der Musterlösung finden Sie auch eine Readme-Datei, in der die Umwandlungsschritte beschrieben sind.
 

--- a/content/posts/grundlagen-datenmanagement/index.mdx
+++ b/content/posts/grundlagen-datenmanagement/index.mdx
@@ -19,7 +19,7 @@ licence: ccby-4.0
 toc: false
 uuid: rm_E5n6gd8cWNCcU5DtXn
 ---
-## Lernziele:
+## Lernziele
 
 - Die Rolle und den Lebenszyklus von Daten in den Geisteswissenschaften verstehen
 - Zentrale Fragen für die Datennutzung und Archivierung beantworten können
@@ -36,18 +36,18 @@ Die Inhalte des Kapitels beruhen auf dem Impulsvortrag „Grundlagen des Datenma
 
 ## A. Einleitung: Daten in der Gesellschaft und Geisteswissenschaftlichen Forschung
 
-Daten begegnen uns in allen Bereichen des Lebens. Zumeist denkt man bei Daten an (Forschungs-)Gebiete wie Statistik, Biologie, Meteorologie, Finanzen oder Transportwesen. Doch Daten sind auch ein zentraler Bestandteil von geisteswissenschaftlichen Forschungen. Je nach Disziplin und Fragestellung arbeiten die Geisteswissenschaften mit unterschiedlichen Arten von Daten und Materialien, wie zum Beispiel:  
+Daten begegnen uns in allen Bereichen des Lebens. Zumeist denkt man bei Daten an (Forschungs-)Gebiete wie Statistik, Biologie, Meteorologie, Finanzen oder Transportwesen. Doch Daten sind auch ein zentraler Bestandteil von geisteswissenschaftlichen Forschungen. Je nach Disziplin und Fragestellung arbeiten die Geisteswissenschaften mit unterschiedlichen Arten von Daten und Materialien, wie zum Beispiel:
 
-- Primär- und Sekundärtexte, 
-- Audio und Videomaterial, 
-- Bilder und Objekte, 
+- Primär- und Sekundärtexte,
+- Audio und Videomaterial,
+- Bilder und Objekte,
 - 3D-Daten und Geoinformationsdaten oder auch
-- Tabellen, Simulationen und Datenbanken. (Siehe Andorfer, „[Forschungsdaten in den (digitalen) Geisteswissenschaften](https://nbn-resolving.org/urn:nbn:de:gbv:7-dariah-2015-7-2)"; und DFG, „[Umgang mit Forschungsdaten](https://www.dfg.de/foerderung/grundlagen_rahmenbedingungen/gwp/index.html)“.) 
+- Tabellen, Simulationen und Datenbanken. (Siehe Andorfer, „[Forschungsdaten in den (digitalen) Geisteswissenschaften](https://nbn-resolving.org/urn:nbn:de:gbv:7-dariah-2015-7-2)"; und DFG, „[Umgang mit Forschungsdaten](https://www.dfg.de/foerderung/grundlagen_rahmenbedingungen/gwp/index.html)“.)
 
-Je nach Forschungsgebiet wird in den Geisteswissenschaften nicht nur mit bestehenden Daten gearbeitet, sondern oftmals werden neue Daten produziert, zum Beispiel durch Umfragen, Audio- und Videoaufzeichnungen oder Digitalisierungen (siehe: DFG, „[Umgang mit Forschungsdaten](https://www.dfg.de/foerderung/grundlagen_rahmenbedingungen/gwp/index.html)“). 
+Je nach Forschungsgebiet wird in den Geisteswissenschaften nicht nur mit bestehenden Daten gearbeitet, sondern oftmals werden neue Daten produziert, zum Beispiel durch Umfragen, Audio- und Videoaufzeichnungen oder Digitalisierungen (siehe: DFG, „[Umgang mit Forschungsdaten](https://www.dfg.de/foerderung/grundlagen_rahmenbedingungen/gwp/index.html)“).
 Im Sinne der guten wissenschaftlichen Praxis (siehe: [ÖAWI](https://oeawi.at/richtlinien), [FWF, Research Integrity](https://www.fwf.ac.at/de/forschungsfoerderung/forschungsintegritaet-forschungsethik) und [DFG](https://www.dfg.de/foerderung/grundlagen_rahmenbedingungen/gwp/index.html)) sollten am Ende eines Projekts nicht nur die Ergebnisse, sondern auch die zugrunde liegenden Daten veröffentlicht werden. Dies erfordert, dass (Forschungs-)Daten nicht nur während des Projekts, sondern auch nach Ende des eigenen Forschungsprojekts langfristig zugänglich, wiederverwendbar, überprüfbar und reproduzierbar werden - unabhängig von ursprünglichen Datenersteller*innen oder Projektkontext. Zu diesem Zweck müssen die Daten während aller Projektphasen von der Planung bis zum Abschluss oder - anders ausgedrückt - während ihres gesamten Datenlebenszyklus verwaltet werden. Um eine möglichst reibungslose Arbeit mit den Daten während des Projekts und deren Nachnutzbarkeit zu gewährleisten, ist ein gutes Datenmanagement unerlässlich.
 
-**Einstiegsfragen:** 
+**Einstiegsfragen:**
 
 Denken Sie an Ihre eigene Forschungsdisziplin und/oder Ihr Forschungsprojekt. Welche Antworten treffen auf Sie zu? Die Fragen dienen lediglich der Orientierung und es kann auch mehr als eine Antwort zutreffend sein.
 
@@ -231,7 +231,7 @@ Für weiterführende Informationen, Richtlinien und Beispiele für Datenmanageme
 
 ### C.2. Schritt 2: Daten effizient organisieren und strukturieren
 
-Ein sicherer Ort für die Datenablage ist gefunden, doch dieser allein reicht noch nicht aus. Damit man sich an diesem Ort nicht verläuft und anderen (und auch sich selbst) dabei hilft, bestimmte Daten schnell und auch nach einer (kürzeren oder längeren) Pause die Inhalte rasch und effizient zu finden, verstehen und nutzen zu können, ist es sinnvoll, sich vorab klare Regeln für die Benennung von Dateien und Ordnern und geeignete Ordnerstrukturen zu überlegen. Dieses Kapitel stellt einige leicht umzusetzende Best-Practice Beispiele vor, die einfach auf eigene Forschungsprojekte angewendet werden können. 
+Ein sicherer Ort für die Datenablage ist gefunden, doch dieser allein reicht noch nicht aus. Damit man sich an diesem Ort nicht verläuft und anderen (und auch sich selbst) dabei hilft, bestimmte Daten schnell und auch nach einer (kürzeren oder längeren) Pause die Inhalte rasch und effizient zu finden, verstehen und nutzen zu können, ist es sinnvoll, sich vorab klare Regeln für die Benennung von Dateien und Ordnern und geeignete Ordnerstrukturen zu überlegen. Dieses Kapitel stellt einige leicht umzusetzende Best-Practice Beispiele vor, die einfach auf eigene Forschungsprojekte angewendet werden können.
 
 <Figure src="images/copyofcopy_1.png">
 Abbildung: "Protip: Never look in someone else's documents folder", von Randall Munroe, [xkcd.com](https://xkcd.com), lizenziert unter [CC-BY-NC 2.5](https://creativecommons.org/licenses/by-nc/2.5/).
@@ -335,7 +335,7 @@ Das (Speicher-)Datum wird zwar auch von Rechnern in den Details einer Datei ange
 </Quiz>
 
 
-#### Strukturierung und Aufbau von Ordnern:
+#### Strukturierung und Aufbau von Ordnern
 
 Sobald geeignete Dateibenennungskonventionen für das Projekt festgelegt wurden, folgt im nächsten Schritt die Überlegung, wie die eindeutig und konsequent benannten Dateien nun in Ordner strukturiert werden können. Die 5S-Methode (siehe Fuchs, "[How do I use 5S method](https://blogs.helsinki.fi/thinkopen/5s-method/)") bietet sich hierfür an. Die „5S“ stehen hierbei für:
 
@@ -437,7 +437,7 @@ Auf der Seite [semverdoc](https://semverdoc.org/) _(Semantic Versioning for Docu
 
 **Weiterführende Literatur und Links:**
 
-- (semver) - Preston-Werner, Tom: "[Semantic Versioning 2.0.0.](https://semver.org/)" 
+- (semver) - Preston-Werner, Tom: "[Semantic Versioning 2.0.0.](https://semver.org/)"
 - (semverdoc) - Tekampe, Nils: "[Semantic Versioning for Documents and Meaningful Manual Version Control.](https://semverdoc.org/)"
 - Stanford Libraries. "[Version Files.](https://guides.library.stanford.edu/data-best-practices/version-files)" _Data Best Practices and Case Studies_. Standford University, 2022.
 - Trognitz, Martina. „[Versionskontrolle.](https://ianus-fdz.de/versionskontrolle)“ _IANUS_, 18.11.2017.
@@ -463,28 +463,28 @@ Sie sollten sich auch vorab mit den Standards und Anforderungen in Ihrem Fachber
 
 [ARCHE (A Resource Centre for the Humanities)](https://arche.acdh.oeaw.ac.at/browser/), ein Service des [ACDH-CH (Austrian Centre for Digital Humanities and Cultural Heritage)](https://www.oeaw.ac.at/acdh/) für die Langzeitarchivierung digitaler Forschungsdaten und -services bevorzugt beispielsweise folgende Dateiformate:
 
-- **Formatierter Text: PDF/A-1, PDF/A-2**  
+- **Formatierter Text: PDF/A-1, PDF/A-2**
 
   - anstatt von: PDF, docx, doc
-- **Strukturierter Text: xml, html, txt, md, text (UTF-8, no BOM)**; 
+- **Strukturierter Text: xml, html, txt, md, text (UTF-8, no BOM)**;
 
   - anstatt von: PDF, docx, doc, odt, indd
-- **Plain (reiner) Text: txt (UTF-8, no BOM)** 
+- **Plain (reiner) Text: txt (UTF-8, no BOM)**
 
   - anstatt von: PDF, docx, odt
-- **Bilder: tiff, dng** 
+- **Bilder: tiff, dng**
 
   - anstatt von: jpeg, psd, gif
 - **Vektorgrafiken:** **svg**
 
   - anstatt von: ai, indd, ps, dwg, dxf
-- **Tabellen:** **csv (UTF-8, no BOM)** 
+- **Tabellen:** **csv (UTF-8, no BOM)**
 
   - anstatt von: xlsx, xls, ods
 
 **Weitere Hinweise zu Textdokumenten und deren möglichen Formaten:**
 
-Wenn die langfristige Erhaltung der optischen Darstellung eines Textdokumentes im Vordergrund steht, sollte ein geeignetes Format für formatierten Text, wie PDF/A gewählt werden. Steht jedoch die Bearbeitbarkeit und vor allem die Erhaltung der Strukturierung im Vordergrund, sollte ein entsprechend geeignetes Format, wie etwa TEI/XML verwendet werden. 
+Wenn die langfristige Erhaltung der optischen Darstellung eines Textdokumentes im Vordergrund steht, sollte ein geeignetes Format für formatierten Text, wie PDF/A gewählt werden. Steht jedoch die Bearbeitbarkeit und vor allem die Erhaltung der Strukturierung im Vordergrund, sollte ein entsprechend geeignetes Format, wie etwa TEI/XML verwendet werden.
 
 Wann immer eine [Zeichenkodierung](https://ianus-fdz.de/it-empfehlungen/textdokumente#text-kodierung) für ein Format wählbar ist, sollte UTF-8 ohne BOM ([Unicode](https://home.unicode.org/)) gewählt werden. Unicode ist ein Standard, der zum einen beschreibt, wie Schrift elektronisch gespeichert wird und zum anderen einen umfangreichen Zeichensatz zur Darstellung von Schriftzeichen aus über 150 Sprachen bereitstellt. Im Gegensatz dazu kann ASCII lediglich 256 Zeichen kodieren, was bei Texten mit Umlauten oder Zeichen aus anderen Sprachen schon nicht mehr ausreicht. Üblicherweise kann die Zeichenkodierung für alle rein textbasierten Formate wie csv, txt, oder auch xml gewählt werden.
 
@@ -496,7 +496,7 @@ Wann immer eine [Zeichenkodierung](https://ianus-fdz.de/it-empfehlungen/textdoku
 
 ### C.5. Schritt 5: Die schriftliche Dokumentation
 
-Für ein konsistentes Datenmanagement ist eine schriftliche Dokumentation von zentraler Bedeutung. Dies gilt insbesondere für der Zusammenarbeit mit anderen Personen, Forschungseinrichtungen und externen Dienstleistern. Auch mit Hinblick auf Vorgaben von Fördergeber*innen und Archiven ist eine schriftliche Dokumentation hilfreich und erleichtert die Arbeit enorm. 
+Für ein konsistentes Datenmanagement ist eine schriftliche Dokumentation von zentraler Bedeutung. Dies gilt insbesondere für der Zusammenarbeit mit anderen Personen, Forschungseinrichtungen und externen Dienstleistern. Auch mit Hinblick auf Vorgaben von Fördergeber*innen und Archiven ist eine schriftliche Dokumentation hilfreich und erleichtert die Arbeit enorm.
 
 Die schriftliche Dokumentation sollte Aufschluss darüber geben, wie gearbeitet wird bzw. wurde und in welchen Schritten die Bearbeitung der Daten erfolgte (wer, wann und was wurde geändert). Folgende Fragen sollte die Dokumentation daher klar beantworten können:
 

--- a/content/posts/introduction-to-dictionary-users/index.mdx
+++ b/content/posts/introduction-to-dictionary-users/index.mdx
@@ -19,11 +19,11 @@ toc: false
 uuid: -c3FYRejn4iB27yy08D9D
 ---
 
-## Summary:
+## Summary
 
 The goal of this course is to introduce students to the important role played by dictionary usage research when developing and implementing new dictionaries. The course will address the question of how different types of target users (in terms of age, language proficiency and pre-existing skills) or different types of use (encoding, decoding, translation etc.) influence the scope of the dictionary, the lemma selection process or the very structure of a dictionary entry. At the end of this course, students will have a fundamental understanding of the ways in which user research (both commercially and academically) can contribute to the tailoring of lexicographic content. Going beyond the realm of user-centered lexicography, the course will also explore possible user contributions in the creation of content and the increasing importance of crowdsourcing in lexicography.
 
-## Learning outcomes:
+## Learning outcomes
 
 Upon completion of this course, students will be able to:
 
@@ -46,7 +46,7 @@ There are various types of dictionary users, differing in age, education, langua
 
 There are many criteria that can be used to classify dictionaries. If we use form as a criteria, we can distinguish between monolingual, covering only one language, bilingual, covering two languages and multilingual, covering more than two languages. Many bilingual dictionaries are bidirectional which means they actually contain two dictionaries in one; of the two languages involved, one is once a source language and once a target language. Let us assume we are planning a general bilingual dictionary for Italian - German/ German-Italian.
 
-### Expected users:
+### Expected users
 
 One of the main users groups of this dictionary are translators, as one of the purposes of the dictionary is assisting in translation tasks (this is also mentioned on the dictionary cover). Translators as a user group is a heterogeneous group and can be divided into two sub-user groups: translation students and professional translators.
 
@@ -158,7 +158,7 @@ The main message of this course is that when planning a dictionary, make sure yo
 
 Research in dictionary use is on the rise, but much more work needs to be done. On the one hand, geographical gaps need to be filled as dictionary use in some countries and/or for languages is poorly studied or not studied at all. On the other hand, digital era has brought new challenges, changing user habits and needs, not only in using dictionaries but also in other activities. Dictionaries are yet to fully exploit all the potential of technological advancements, and it will be paramount to consider users when making these dictionaries of the future.
 
-## References:
+## References
 
 Arhar Holdt, Špela, Kosem, Iztok, Gantar, Polona. 2016. "Dictionary user typology: the Slovenian case". In: MARGALITADZE, Tinatin (ed.), MELADZE, George (ed.). _Lexicography and linguistic diversity: Proceedings of the XVII EURALEX International Congress_, 6-10 September, 2016. Ivane Javakhishvili Tbilisi State University. p.179-187.
 

--- a/content/posts/introduction-to-figma/index.mdx
+++ b/content/posts/introduction-to-figma/index.mdx
@@ -17,7 +17,7 @@ licence: ccby-4.0
 toc: false
 uuid: WED6ORN_hrTvWstoK3kRw
 ---
-## Learning Objectives:
+## Learning Objectives
 
 - Readers can sign up to Figma and create teams
 - Readers can create mock-ups of UIs (user interfaces) in Figma


### PR DESCRIPTION
this removes trailing colons from headings, which are confusing when headings are listed in a table-of-contents outline.